### PR TITLE
Link assets to html

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,7 @@
 {
-  "extends": "google"
+  "extends": "google",
+
+  "rules":{
+    "linebreak-style": 0
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>To Do</title>
+    <link type="text/css" rel="stylesheet" href="assets/css/index.css">
+    <title>2DO</title>
 </head>
 <body>
-    
+  <div id="app"></div>
+  <script type="text/javascript" src="assets/js/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
# Por quê?
Para o html ter acesso aos arquivos de estilo e funcionais.

# O quê?
- Referenciar os arquivos assets no html.
- Ajustar o eslint para quebra de linhas linux/windows.